### PR TITLE
more robust dataview init in wispbuffer

### DIFF
--- a/src/packet.mjs
+++ b/src/packet.mjs
@@ -25,7 +25,7 @@ export class WispBuffer {
   from_array(bytes) {
     this.size = bytes.length;
     this.bytes = bytes;
-    this.view = new DataView(bytes.buffer); 
+    this.view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength); 
   }
 
   concat(buffer) {


### PR DESCRIPTION
in some environments, the extent of a `Uint8Array` will not be the same as its buffer. this configures the dataview to connect to the buffer but use the array's extents.